### PR TITLE
Add multipackage repo support

### DIFF
--- a/README.md
+++ b/README.md
@@ -18,6 +18,7 @@ Here are some things you can do to get started with CDep.
 * [Contribute to CDep](https://github.com/google/cdep/blob/master/CONTRIBUTING.md)
 * [Request a new package or submit a bug report](https://github.com/google/cdep/issues/new)
 * [See an Android Studio Freetype and SDL2 sample](https://github.com/jomof/cdep-android-studio-freetype-sample/tree/master)
+* [Learn how CDep resolves coordinates](doc/coordinate-resolution.md)
 
 ## Getting started on Windows
 Get started with CDep on Windows, enter the following in the command line:

--- a/cdep/src/main/java/io/cdep/cdep/resolver/GithubMultipackageCoordinateResolver.java
+++ b/cdep/src/main/java/io/cdep/cdep/resolver/GithubMultipackageCoordinateResolver.java
@@ -1,0 +1,73 @@
+package io.cdep.cdep.resolver;
+
+import io.cdep.annotations.NotNull;
+import io.cdep.annotations.Nullable;
+import io.cdep.cdep.yml.cdep.SoftNameDependency;
+
+import java.io.IOException;
+import java.security.NoSuchAlgorithmException;
+import java.util.regex.Matcher;
+import java.util.regex.Pattern;
+
+import static java.util.regex.Pattern.compile;
+
+/**
+ * This resolver locates a package by using a coordinate that is transformed into a github URL. It allows a single
+ * Github repo to host multple packages. For example,
+ *
+ *   - compile: com.github.google.cdep:sqlite:1.2.3
+ *
+ * Is decomposed into:
+ *
+ *   host = github.com
+ *   domain = google
+ *   project = cdep
+ *   artifact = sqlite
+ *   version = 1.2.3
+ *
+ * then these fields are recomposed into:
+ *
+ *   http://[host]/[domain]/releases/download/[artifact]-[version]/cdep-manifest.yml
+ *
+ *      -->
+ *
+ *   http://github.com/google/releases/download/sqlite-1.2.3/cdep-manifest.yml
+ */
+public class GithubMultipackageCoordinateResolver extends CoordinateResolver {
+
+  final private Pattern pattern = compile("^com\\.github\\.(.*)\\.(.*):(.*):(.*)$");
+  final private CoordinateResolver urlResolver;
+
+  GithubMultipackageCoordinateResolver() {
+    this.urlResolver = new GithubStyleMultipackageUrlCoordinateResolver();
+  }
+
+  @Nullable
+  @Override
+  public ResolvedManifest resolve(@NotNull ManifestProvider environment, @NotNull SoftNameDependency dependency)
+      throws IOException, NoSuchAlgorithmException {
+    String coordinate = dependency.compile;
+    assert coordinate != null;
+    Matcher match = pattern.matcher(coordinate);
+    if (match.find()) {
+      String domain = match.group(1);
+      String project = match.group(2);
+      String artifact = match.group(3);
+      String version = match.group(4);
+      String subArtifact = "";
+      if (artifact.contains("/")) {
+        int pos = artifact.indexOf("/");
+        subArtifact = "-" + artifact.substring(pos + 1);
+        artifact = artifact.substring(0, pos);
+      }
+      String manifest = String.format("https://github.com/%s/%s/releases/download/%s@%s/cdep-manifest%s.yml",
+          domain,
+          project,
+          artifact,
+          version,
+          subArtifact);
+      return urlResolver.resolve(environment, new SoftNameDependency(manifest));
+    }
+    return null;
+  }
+}

--- a/cdep/src/main/java/io/cdep/cdep/resolver/GithubReleasesCoordinateResolver.java
+++ b/cdep/src/main/java/io/cdep/cdep/resolver/GithubReleasesCoordinateResolver.java
@@ -26,10 +26,34 @@ import java.util.regex.Pattern;
 
 import static java.util.regex.Pattern.compile;
 
+/**
+ * This resolver locates a package by using a coordinate that is transformed into a github URL. For example,
+ *
+ *   - compile: com.github.jomof:sqlite:1.2.3
+ *
+ * Is decomposed into:
+ *
+ *   host = github.com
+ *   subhost = jomof
+ *   artifact = sqlite
+ *   version = 1.2.3
+ *
+ * then these fields are recomposed into:
+ *
+ *   http://[host]/[subhost]/[artifact]/releases/download/[version]/cdep-manifest.yml
+ */
 public class GithubReleasesCoordinateResolver extends CoordinateResolver {
 
-  final private Pattern pattern = compile("^com\\.github\\.(.*):(.*):(.*)$");
-  final private GithubStyleUrlCoordinateResolver urlResolver = new GithubStyleUrlCoordinateResolver();
+  final private Pattern pattern = compile("^com\\.github\\.([^\\.]+):(.*):(.*)$");
+  final private CoordinateResolver urlResolver;
+
+  GithubReleasesCoordinateResolver() {
+    this.urlResolver = new GithubStyleUrlCoordinateResolver();
+  }
+
+  GithubReleasesCoordinateResolver(CoordinateResolver urlResolver) {
+    this.urlResolver = urlResolver;
+  }
 
   @Nullable
   @Override

--- a/cdep/src/main/java/io/cdep/cdep/resolver/LocalFilePathCoordinateResolver.java
+++ b/cdep/src/main/java/io/cdep/cdep/resolver/LocalFilePathCoordinateResolver.java
@@ -28,6 +28,13 @@ import java.nio.file.Paths;
 
 import static java.nio.charset.StandardCharsets.UTF_8;
 
+/**
+ * This resolver allows you to reference a package by it's local file path:
+ *
+ * - compile: /path/to/cdep-manifest.yml
+ *
+ * The use case is testing packages and hosting private packages.
+ */
 public class LocalFilePathCoordinateResolver extends CoordinateResolver {
 
   @Nullable

--- a/cdep/src/main/java/io/cdep/cdep/resolver/Resolver.java
+++ b/cdep/src/main/java/io/cdep/cdep/resolver/Resolver.java
@@ -30,14 +30,33 @@ import static io.cdep.cdep.utils.Invariant.fail;
 import static io.cdep.cdep.utils.Invariant.require;
 
 /**
- * Resolve references and groups of references (ResolutionScope)
+ * A resolver is responsible for locating a CDep manifest given only a coordinate.
+ *
+ * For example,
+ *   - compile: com.github.jomof:sqlite:1.2.3
+ *
+ * Is decomposed into:
+ *
+ *   host = github.com
+ *   subhost = jomof
+ *   artifact = sqlite
+ *   version = 1.2.3
+ *
+ * then these fields are recomposed into:
+ *
+ *   http://[host]/[subhost]/[artifact]/releases/download/[version]/cdep-manifest.yml
+ *
+ * If this URL exists then it is used. Otherwise, it is a failure.
  */
 public class Resolver {
 
   final private static CoordinateResolver RESOLVERS[] = new CoordinateResolver[] {
       new GithubStyleUrlCoordinateResolver(),
       new GithubReleasesCoordinateResolver(),
-      new LocalFilePathCoordinateResolver() };
+      new LocalFilePathCoordinateResolver(),
+      new GithubStyleMultipackageUrlCoordinateResolver(),
+      new GithubMultipackageCoordinateResolver(),
+  };
 
   final private ManifestProvider manifestProvider;
   final private CoordinateResolver resolvers[];

--- a/cdep/src/main/java/io/cdep/cdep/utils/GithubUtils.java
+++ b/cdep/src/main/java/io/cdep/cdep/utils/GithubUtils.java
@@ -1,0 +1,33 @@
+/*
+ * Copyright 2017 Google Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+*/
+package io.cdep.cdep.utils;
+
+import java.net.MalformedURLException;
+import java.net.URL;
+
+/**
+ * Methods for dealing with github.
+ */
+public class GithubUtils {
+  /**
+   * Replace characters that are special to Github URLs (in particular the releases URLs).
+   */
+  public static URL escapeGithubSpecialCharacters(URL url) throws MalformedURLException {
+    String value = url.toString();
+    value = value.replace("@", "%40");
+    return new URL(value);
+  }
+}

--- a/cdep/src/test/java/io/cdep/cdep/resolver/TestGithubMultipackageCoordinateResolver.java
+++ b/cdep/src/test/java/io/cdep/cdep/resolver/TestGithubMultipackageCoordinateResolver.java
@@ -1,0 +1,61 @@
+/*
+ * Copyright 2017 Google Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+*/
+package io.cdep.cdep.resolver;
+
+import io.cdep.cdep.Coordinate;
+import io.cdep.cdep.generator.GeneratorEnvironment;
+import io.cdep.cdep.yml.cdep.SoftNameDependency;
+import io.cdep.cdep.yml.cdepmanifest.CDepManifestYml;
+import org.junit.Test;
+
+import java.io.File;
+import java.io.IOException;
+import java.net.URL;
+import java.security.NoSuchAlgorithmException;
+
+import static com.google.common.truth.Truth.assertThat;
+import static org.junit.Assert.*;
+
+public class TestGithubMultipackageCoordinateResolver {
+  final private GeneratorEnvironment environment = new GeneratorEnvironment(
+      new File("./test-files/TestGithubMultipackageCoordinateResolver/working"),
+      null,
+      false,
+      false);
+
+  @Test
+  public void testCompound() throws Exception {
+    final ManifestProvider manifestProvider = new ManifestProvider() {
+      @Override
+      public CDepManifestYml tryGetManifest(Coordinate coordinate, URL remoteArchive)
+          throws IOException, NoSuchAlgorithmException {
+        assertThat(remoteArchive.toString()).isEqualTo(
+            "https://github.com/google/cdep/releases/download/firebase%402.1.3-rev5/cdep-manifest-database.yml");
+        return new CDepManifestYml(coordinate);
+      }
+    };
+
+    ResolvedManifest resolved = new GithubMultipackageCoordinateResolver()
+        .resolve(
+            manifestProvider,
+            new SoftNameDependency("com.github.google.cdep:firebase/database:2.1.3-rev5"));
+    assert resolved != null;
+    assert resolved.cdepManifestYml.coordinate != null;
+    assertThat(resolved.cdepManifestYml.coordinate.groupId).isEqualTo("com.github.google.cdep");
+    assertThat(resolved.cdepManifestYml.coordinate.artifactId).isEqualTo("firebase/database");
+    assertThat(resolved.cdepManifestYml.coordinate.version.value).isEqualTo("2.1.3-rev5");
+  }
+}

--- a/doc/coordinate-resolution.md
+++ b/doc/coordinate-resolution.md
@@ -1,0 +1,69 @@
+## CDep coordinate resolution
+A CDep coordinate uniquely identifies a package. It also contains the information needed to reconstruct a URL to the package's manifest. Here's an example:
+
+```
+com.github.jomof:sqlite:3.16.2-rev51
+```
+
+There are multiple coordinate forms that are used to solve different problems.
+
+### Simple form
+The simplest coordinate form looks like this:
+```
+com.github.jomof:sqlite:3.16.2-rev51
+```
+During resolution, CDep decomposes this into pieces.
+```
+domain = github.com
+user = jomof
+artifact = sqlite
+version = 3.16.2-rev51
+```
+CDep then recomposes these pieces into a URL:
+```
+https://github.com/jomof/sqlite/releases/download/3.16.2-rev53/cdep-manifest.yml
+```
+The purpose of the simple form of coordinate is just to be able to host the source and releases for a single CDep package.
+
+### Compound form
+Sometimes you want a family of packages under a single umbrella repo. Coordinates of this form look like this:
+```
+com.github.jomof:firebase/admob:2.1.3-rev22
+com.github.jomof:firebase/analytics:2.1.3-rev22
+```
+These are decomposed in a manner similar to the simple form. The single difference is that the artifact family name is extracted:
+```
+domain = github.com
+user = jomof
+family = firebase
+artifact = admob
+version = 2.1.3-rev22
+```
+Artifact family name is then used to recompose the URL by adding a suffix to the CDep manifest file name.
+```
+https://github.com/jomof/firebase/releases/download/2.1.3-rev23/cdep-manifest-admob.yml
+```
+
+### Multipackage form
+Sometimes you want to use a single Github repo to hold multiple unrelated packages. In this case, you use the multi package form:
+```
+com.github.jomof.cdep:boost:1.0.63
+```
+The difference is that the group name has four segments rather than three. The final segment is the name of Github repo for the given user. CDep transforms this into a manifest URL similar to this one:
+```
+https://github.com/jomof/cdep/releases/download/boost@1.0.63/cdep-manifest.yml
+```
+The URL form actually needs to '@' to be escaped. So the true URL is like this:
+```
+https://github.com/jomof/cdep/releases/download/boost%401.0.63/cdep-manifest.yml
+```
+However, when you create the new Github release to hold this package you should create it with the @ symbol (like boost@1.0.63).
+
+Multipackage form also supports compound packages. These have a coordinate like this:
+```
+com.github.jomof.cdep:firebase/admob:2.1.3-rev22
+```
+
+
+
+


### PR DESCRIPTION
Adds support for coordinates like:
com.github.google.cdep:zlib:1.2.3

So that a single Github repo can host multiple unrelated packages (so we don't have to go back and ask for new repo each time we want to publish a package)