### PR TITLE
Issue 28 -- Wrong SHA256 written during failure to read package manifest

### DIFF
--- a/cdep/src/main/java/io/cdep/CDep.java
+++ b/cdep/src/main/java/io/cdep/CDep.java
@@ -588,12 +588,6 @@ public class CDep {
     environment.readCDepSHA256File();
     FunctionTableExpression table = getFunctionTableExpression(environment);
 
-    // Download and unzip archives.
-    //GeneratorEnvironmentUtils.downloadReferencedModules(environment, ExpressionUtils.getAllFoundModuleExpressions(table));
-
-    // Check that the expected files were downloaded
-    //new CheckLocalFileSystemIntegrity(environment.unzippedArchivesFolder).visit(table);
-
     runBuilders(environment, table);
     environment.writeCDepSHA256File();
   }

--- a/cdep/src/main/java/io/cdep/cdep/Coordinate.java
+++ b/cdep/src/main/java/io/cdep/cdep/Coordinate.java
@@ -62,6 +62,9 @@ public class Coordinate {
   @NotNull
   @Override
   public String toString() {
+    if (groupId.isEmpty() && artifactId.isEmpty()) {
+      return "";
+    }
     if (version.value.length() > 0) {
       return groupId + ":" + artifactId + ":" + version;
     }

--- a/cdep/src/main/java/io/cdep/cdep/resolver/GithubStyleUrlCoordinateResolver.java
+++ b/cdep/src/main/java/io/cdep/cdep/resolver/GithubStyleUrlCoordinateResolver.java
@@ -28,6 +28,7 @@ import java.security.NoSuchAlgorithmException;
 import java.util.regex.Matcher;
 import java.util.regex.Pattern;
 
+import static io.cdep.cdep.utils.Invariant.errorsInScope;
 import static io.cdep.cdep.utils.Invariant.require;
 
 
@@ -70,6 +71,11 @@ public class GithubStyleUrlCoordinateResolver extends CoordinateResolver {
       CDepManifestYml cdepManifestYml = environment.tryGetManifest(provisionalCoordinate, new URL(coordinate));
       if (cdepManifestYml == null) {
         // The URL didn't exist.
+        return null;
+      }
+
+      if (errorsInScope() > 0) {
+        // There were errors reading the manifest. Don't try to recover.
         return null;
       }
 

--- a/cdep/src/test/java/io/cdep/TestCDep.java
+++ b/cdep/src/test/java/io/cdep/TestCDep.java
@@ -351,6 +351,33 @@ public class TestCDep {
   }
 
   @Test
+  public void oldBoost() throws Exception {
+    CDepYml config = new CDepYml();
+    System.out.printf(new Yaml().dump(config));
+    File yaml = new File(".test-files/oldBoost-12/cdep.yml");
+    yaml.getParentFile().delete();
+    yaml.getParentFile().mkdirs();
+    Files.write("builders: [cmake]\n"
+            + "dependencies:\n"
+            + "- compile: com.github.jomof:boost:1.0.63-rev10\n",
+        yaml, StandardCharsets.UTF_8);
+    String result1 = main("show", "manifest", "-wf", yaml.getParent());
+    yaml.delete();
+    Files.write(result1, yaml, StandardCharsets.UTF_8);
+    System.out.print(result1);
+    try {
+      String result = main("-wf", yaml.getParent());
+      System.out.printf(result);
+      fail("Expected exception");
+    } catch (RuntimeException e) {
+
+    }
+
+    File sha256 = new File(yaml.getParentFile(), "cdep.sha256");
+    assertThat(sha256.exists()).isFalse();
+  }
+
+  @Test
   public void showEmptyManifest() throws Exception {
     CDepYml config = new CDepYml();
     System.out.printf(new Yaml().dump(config));


### PR DESCRIPTION

When there is a failure reading a package manifest do not record SHA256 for that package. This is to avoid recording a wrong value that will be enforced on subsequent runs.
--


