### PR TITLE
Fix broken uses `ls`

### DIFF
--- a/doc/authoring.md
+++ b/doc/authoring.md
@@ -135,7 +135,7 @@ Last, we need add the size of the zip file to the manifest.
 
 ```
 printf "    size: " >> upload/cdep-manifest.yml
-ls -l upload/boringssl-tutorial-headers.zip | awk '{print $5}' >> upload/cdep-manifest.yml
+stat -c%s upload/boringssl-tutorial-headers.zip >> upload/cdep-manifest.yml
 ```
 ## Step 11 -- Add library file archive to the manifest
 This step is similar to step 10. It adds the zipped libraries archive along with size and sha256.
@@ -146,7 +146,7 @@ printf "    %s\r\n" "- file: boringssl-tutorial-armeabi.zip" >> upload/cdep-mani
 printf "      sha256: " >> upload/cdep-manifest.yml
 shasum -a 256 upload/boringssl-tutorial-armeabi.zip | awk '{print $1}' >> upload/cdep-manifest.yml
 printf "      size: " >> upload/cdep-manifest.yml
-ls -l upload/boringssl-tutorial-armeabi.zip | awk '{print $5}' >> upload/cdep-manifest.yml
+stat -c%s upload/boringssl-tutorial-armeabi.zip >> upload/cdep-manifest.yml
 ```
 Specify the ABI that the libraries target.
 ```


### PR DESCRIPTION
Parsing `ls` is notoriously fragile and should be avoided when possible.

In this case, `ls` was an alias to `ls -h` for me, resulting in `3.0K` as a file size instead of a number of bytes. Let's replace it with the reliable `stat` instead (which is part of `coreutils`, just like the `printf` used in the rest of these instructions).

While fixing that, I noticed the `cdep` and `gradlew` script also parse `ls`, to read links; let's use `readlink` instead (also part of `coreutils`), as the current code would break if any part of the link or its derefs contained `-> ` (uncommon, granted). You could test that breakage with this, for instance:

    $ ln -s 'bar -> baz' foo